### PR TITLE
Fix failing specs

### DIFF
--- a/src/hooks/__tests__/audit-logging.hook.spec.ts
+++ b/src/hooks/__tests__/audit-logging.hook.spec.ts
@@ -1,4 +1,3 @@
-import { Test, TestingModule } from '@nestjs/testing';
 import { ExecutionContext, CallHandler } from '@nestjs/common';
 import { of } from 'rxjs';
 import {
@@ -74,12 +73,15 @@ describe('Audit Logging Hook', () => {
     let storage: InMemoryAuditStorage;
     let context: Partial<ExecutionContext>;
     let callHandler: Partial<CallHandler>;
+    let handler: () => void;
 
     beforeEach(() => {
       storage = new InMemoryAuditStorage();
       interceptor = new AuditInterceptor(storage);
+      handler = () => {};
       context = {
-        getHandler: () => () => {},
+        getHandler: () => handler,
+        getClass: () => class TestController {},
         switchToHttp: () => ({
           getRequest: () => ({
             user: { id: '1', email: 'test@test.com' },
@@ -97,11 +99,7 @@ describe('Audit Logging Hook', () => {
     });
 
     it('should intercept and save audit log', (done) => {
-      Reflect.defineMetadata(
-        'audit-config',
-        { action: 'READ' },
-        context.getHandler(),
-      );
+      Reflect.defineMetadata('audit-config', { action: 'READ' }, handler);
       interceptor
         .intercept(context as ExecutionContext, callHandler as CallHandler)
         .subscribe(() => {

--- a/src/hooks/__tests__/audit.hook.spec.ts
+++ b/src/hooks/__tests__/audit.hook.spec.ts
@@ -1,4 +1,3 @@
-import { Test, TestingModule } from '@nestjs/testing';
 import { ExecutionContext, CallHandler } from '@nestjs/common';
 import { of } from 'rxjs';
 import {
@@ -74,12 +73,15 @@ describe('Audit Hook', () => {
     let storage: InMemoryAuditStorage;
     let context: Partial<ExecutionContext>;
     let callHandler: Partial<CallHandler>;
+    let handler: () => void;
 
     beforeEach(() => {
       storage = new InMemoryAuditStorage();
       interceptor = new AuditInterceptor(storage);
+      handler = () => {};
       context = {
-        getHandler: () => () => {},
+        getHandler: () => handler,
+        getClass: () => class TestController {},
         switchToHttp: () => ({
           getRequest: () => ({
             user: { id: '1', email: 'test@test.com' },
@@ -97,11 +99,7 @@ describe('Audit Hook', () => {
     });
 
     it('should intercept and save audit log', (done) => {
-      Reflect.defineMetadata(
-        'audit-config',
-        { action: 'READ' },
-        context.getHandler(),
-      );
+      Reflect.defineMetadata('audit-config', { action: 'READ' }, handler);
       interceptor
         .intercept(context as ExecutionContext, callHandler as CallHandler)
         .subscribe(() => {

--- a/src/hooks/__tests__/order-by-field.guard.spec.ts
+++ b/src/hooks/__tests__/order-by-field.guard.spec.ts
@@ -65,15 +65,18 @@ describe('OrderByFieldValidationGuard', () => {
   });
 
   it('allows entity columns if TypeORM present', async () => {
+    const User = class User {};
     // Mock TypeORM getMetadataArgsStorage
     jest.resetModules();
     jest.doMock('typeorm', () => ({
       getMetadataArgsStorage: () => ({
-        columns: [{ target: class User {}, propertyName: 'username' }],
+        columns: [{ target: User, propertyName: 'username' }],
       }),
     }));
-    const User = class User {};
-    const Guard = SortFieldValidationGuard(User);
+    const { SortFieldValidationGuard: GuardFactory } = await import(
+      '../order-by-field.guard'
+    );
+    const Guard = GuardFactory(User);
     const context = getContext({ orderBy: 'username' });
     await expect(new Guard().canActivate(context)).resolves.toBe(true);
     jest.dontMock('typeorm');

--- a/src/hooks/__tests__/resilient-http.hook.spec.ts
+++ b/src/hooks/__tests__/resilient-http.hook.spec.ts
@@ -1,6 +1,7 @@
 import { CircuitBreaker, ResilientHttpService } from '../resilient-http.hook';
 import { CircuitBreakerState } from '../../types/hooks';
 import { of, throwError, lastValueFrom } from 'rxjs';
+import { catchError } from 'rxjs/operators';
 
 describe('CircuitBreaker', () => {
   const config = { failureThreshold: 2, resetTimeout: 100 };
@@ -17,10 +18,10 @@ describe('CircuitBreaker', () => {
   it('should open after failures', async () => {
     const failingOp = () => throwError(() => new Error('fail'));
     await lastValueFrom(
-      await breaker.execute(failingOp).catch(() => of(undefined)),
+      (await breaker.execute(failingOp)).pipe(catchError(() => of(undefined))),
     );
     await lastValueFrom(
-      await breaker.execute(failingOp).catch(() => of(undefined)),
+      (await breaker.execute(failingOp)).pipe(catchError(() => of(undefined))),
     );
     expect(breaker.getStats().state).toBe(CircuitBreakerState.OPEN);
   });
@@ -28,10 +29,10 @@ describe('CircuitBreaker', () => {
   it('should reset to CLOSED after success in HALF_OPEN', async () => {
     const failingOp = () => throwError(() => new Error('fail'));
     await lastValueFrom(
-      await breaker.execute(failingOp).catch(() => of(undefined)),
+      (await breaker.execute(failingOp)).pipe(catchError(() => of(undefined))),
     );
     await lastValueFrom(
-      await breaker.execute(failingOp).catch(() => of(undefined)),
+      (await breaker.execute(failingOp)).pipe(catchError(() => of(undefined))),
     );
     // Simulate time passing for reset
     (breaker as any).nextAttemptTime = new Date(Date.now() - 1);


### PR DESCRIPTION
## Summary
- repair circuit breaker tests using `catchError`
- remove unused `@nestjs/testing` imports
- mock TypeORM correctly and re-import guard for dynamic metadata
- stabilize interceptor handler for audit hook tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867a86403ec8330bd5fcf3d7e20c375