### PR TITLE
Add lightweight audit hook option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,10 @@ A comprehensive toolkit for building robust, scalable, and maintainable NestJS b
 - **Configurable Decorators** for endpoints, roles, permissions, and audit logging
 - **Composite Guards** with AND/OR/NOT logic
 - **Audit Logging** with MongoDB or file-based storage
-- **Audit Logging** with MongoDB or file-based storage
+- **Lightweight in-memory audit option for testing or small apps**
 - **Resilient HTTP** (retry, timeout, circuit breaker) as decorators and services
 - **Validation Pipes** and helpers
 - **Rate Limiting** and caching interceptors
-- **Sort Field Validation Guard** for safe, flexible sorting in list endpoints
 - **Sort Field Validation Guard** for safe, flexible sorting in list endpoints
 - **Full TypeScript generics and enums** for type safety
 - **Extensive configuration options**
@@ -355,6 +354,22 @@ async createOrder(@Body() dto: CreateOrderDto, @CurrentUser() user: User) { ... 
 @Get('sensitive-data/:id')
 async getSensitiveData(@Param('id') id: string) { ... }
 ```
+For minimal setups you can use `SimpleAuditInterceptor` with
+`SimpleInMemoryAuditStorage` and the `SimpleAudit` decorator.  These
+are exported from `@kitstack/nest-powertools` for a lightweight,
+in-memory audit implementation.
+
+```typescript
+const storage = new SimpleInMemoryAuditStorage();
+app.useGlobalInterceptors(new SimpleAuditInterceptor(storage));
+
+@Post('orders')
+@SimpleAudit('CreateOrder')
+create(@Body() dto: CreateOrderDto) {}
+
+// Later
+console.log(storage.getAll()); // inspect saved logs
+```
 
 ### CompositeGuard (see Guards section)
 
@@ -400,6 +415,15 @@ async track(@UserAgent() userAgent: string, @IpAddress() ip: string) { ... }
 ---
 
 ## 🗄️ Audit Logging Storage
+
+### SimpleInMemoryAuditStorage
+- Stores logs in-memory for quick tests or ephemeral setups.
+- **Constructor:**
+```typescript
+new SimpleInMemoryAuditStorage()
+```
+- **Inspect Logs:** `storage.getAll()` returns an array of saved entries.
+- **Reset Logs:** `storage.clear()` empties the in-memory store.
 
 ### FileAuditStorage
 - Stores audit logs in a JSON file. Used automatically if MongoDB is not configured.

--- a/src/hooks/audit-simple.hook.ts
+++ b/src/hooks/audit-simple.hook.ts
@@ -1,0 +1,103 @@
+import {
+  Injectable,
+  NestInterceptor,
+  ExecutionContext,
+  CallHandler,
+  Logger,
+  SetMetadata,
+} from '@nestjs/common';
+import { Observable, throwError } from 'rxjs';
+import { tap, catchError } from 'rxjs/operators';
+import type { AuditConfig, AuditLogEntry, AuditStorage } from '../types/hooks';
+
+/**
+ * Lightweight in-memory storage for audit logs.
+ */
+@Injectable()
+export class SimpleInMemoryAuditStorage implements AuditStorage {
+  private readonly logs: AuditLogEntry[] = [];
+
+  async save(entry: AuditLogEntry): Promise<void> {
+    entry.id = Date.now().toString();
+    this.logs.push(entry);
+  }
+
+  async find(filters: Partial<AuditLogEntry>): Promise<AuditLogEntry[]> {
+    return this.logs.filter((log) =>
+      Object.entries(filters).every(
+        ([k, v]) => log[k as keyof AuditLogEntry] === v,
+      ),
+    );
+  }
+
+  async findById(id: string): Promise<AuditLogEntry | null> {
+    return this.logs.find((log) => log.id === id) || null;
+  }
+
+  /** Convenience helpers for tests */
+  getAll(): AuditLogEntry[] {
+    return [...this.logs];
+  }
+
+  clear(): void {
+    this.logs.length = 0;
+  }
+}
+
+/**
+ * Interceptor that records basic audit information for each request.
+ */
+@Injectable()
+export class SimpleAuditInterceptor implements NestInterceptor {
+  private readonly logger = new Logger(SimpleAuditInterceptor.name);
+
+  constructor(private readonly storage: AuditStorage) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    const config: AuditConfig | undefined = Reflect.getMetadata(
+      'audit-config',
+      context.getHandler(),
+    );
+    if (!config) {
+      return next.handle();
+    }
+
+    const start = Date.now();
+    const req = context.switchToHttp().getRequest();
+    const entry: AuditLogEntry = {
+      userId: req.user?.id || req.user?.sub,
+      action: config.action,
+      resource: config.resource || context.getHandler().name,
+      resourceId: req.params?.id,
+      timestamp: new Date(),
+      requestBody: config.includeRequestBody ? req.body : undefined,
+    };
+
+    return next.handle().pipe(
+      tap(() => {
+        entry.responseStatus = context.switchToHttp().getResponse().statusCode;
+        entry.duration = Date.now() - start;
+        this.storage.save(entry).catch((err) =>
+          this.logger.error('Failed to save audit log', err),
+        );
+      }),
+      catchError((error) => {
+        entry.responseStatus = error.status || 500;
+        entry.duration = Date.now() - start;
+        entry.metadata = { error: error.message };
+        this.storage.save(entry).catch((err) =>
+          this.logger.error('Failed to save audit log', err),
+        );
+        return throwError(() => error);
+      }),
+    );
+  }
+}
+
+/**
+ * Decorator to enable simple audit logging on a controller method.
+ */
+export const SimpleAudit = (
+  action: string,
+  options: Omit<AuditConfig, 'action'> = {},
+): MethodDecorator => SetMetadata('audit-config', { action, ...options });

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,12 @@ export {
   AuditUpdate,
   AuditDelete,
 } from './hooks/audit-logging.hook';
+// Lightweight audit hook exports
+export {
+  SimpleInMemoryAuditStorage,
+  SimpleAuditInterceptor,
+  SimpleAudit,
+} from './hooks/audit-simple.hook';
 
 // Guards and interceptors
 export * from './guards/configurable-auth.guard';
@@ -85,5 +91,6 @@ export {
 export * from './config/guard-registry';
 
 export * from './hooks/audit-logging.hook';
+export * from './hooks/audit-simple.hook';
 export * from './config/powertools.config';
 export * from './powertools.module';


### PR DESCRIPTION
## Summary
- implement `SimpleAuditInterceptor` and in-memory storage
- re-export simplified audit utilities from library index
- document lightweight audit interceptor option in README
- mention lightweight in-memory audit storage
- show how to use `SimpleAuditInterceptor` and view logs

## Testing
- `npm run lint` *(fails: ESLint couldn't find eslint-plugin-prettier)*
- `npm test` *(fails: cannot find module '@nestjs/testing')*


------
https://chatgpt.com/codex/tasks/task_e_6867aad8e2d48330a8332068f599a509